### PR TITLE
Feature/bb bootstrap initial

### DIFF
--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -1,13 +1,34 @@
 #!/bin/sh
 
-#update
+#----validation
+#if $EUID -ne 0; then
+#    echo "You need to install as root by using sudo";
+#    exit
+#fi
+
+#----force ipv4
+if ! grep -q "ipv6.disable=1" /boot/cmdline.txt; then
+    echo " ipv6.disable=1" | sudo tee -a /boot/cmdline.txt
+    echo "We just disabled ipv6 due better network compatibility. It will take effect after restart.";
+fi
+
+#----default DNS (google)
+if ! grep -q "nameserver 8.8.8.8" /etc/resolv.conf; then
+    echo "nameserver 8.8.8.8" | sudo tee -a /etc/resolv.conf
+    echo "nameserver 8.8.4.4" | sudo tee -a /etc/resolv.conf
+fi
+
+#----debian missing locale
+sudo apt-get install language-pack-en
+export LC_ALL="en_US.UTF-8"
+
+#----update raspberry
 sudo apt-get update
 sudo apt-get -y dist-upgrade
 
-#nodejs
+#----nodejs install
 curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
 sudo apt-get install -y nodejs
-sudo ln -s "$(which nodejs)" /usr/bin/node
 
-#alsa
+#----alsa install
 sudo apt-get install -y alsa-base alsa-utils

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -1,2 +1,12 @@
 #!/bin/sh
-echo "This is a placeholder for the TJBot boostrap script. Until it has been written, please follow the directions in README.md to configure your Raspberry Pi for TJBot."
+
+#update
+sudo apt-get update
+sudo apt-get -y dist-upgrade
+
+#nodejs
+curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+#alsa
+sudo apt-get install -y alsa-base alsa-utils

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -7,6 +7,7 @@ sudo apt-get -y dist-upgrade
 #nodejs
 curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
 sudo apt-get install -y nodejs
+sudo ln -s "$(which nodejs)" /usr/bin/node
 
 #alsa
 sudo apt-get install -y alsa-base alsa-utils

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -18,9 +18,10 @@ if ! grep -q "nameserver 8.8.8.8" /etc/resolv.conf; then
     echo "nameserver 8.8.4.4" | sudo tee -a /etc/resolv.conf
 fi
 
-#----debian missing locale
-sudo apt-get install language-pack-en
+#----debian missing locale (just to remove warnigs)
 export LC_ALL="en_US.UTF-8"
+echo "en_US.UTF-8 UTF-8" | sudo tee -a /etc/locale.gen
+sudo locale-gen en_US.UTF-8
 
 #----update raspberry
 sudo apt-get update


### PR DESCRIPTION
Initial version of bootstrap.
Steps automated by that version:

1) Force IPV4: today IPV6 is not a reality in most places. If you have both IPV4 and IPV6 enabled the connection sometimes go over IPV4 and sometime over IPV6. It could cause intermittent problems.

2) Extra DNS: Raspian O.S uses gateway (ex: 192.168.1.1) as default DNS. To avoid problems in networks that don’t have an external DNS configured in gateway, the bootstrap add two extra DNS: 8.8.8.8 and 8.8.4.4 that are provided by google and widely used.

3) Set a debian (raspian) locale just to avoid installation warnings

4) Update rasping O.S

5) Install NodeJS and NPM

6) Install Alsa

Please let’s test that before update the documentation.

Here I have problems with IPV6 (my gadgets only works with IPV4) and it could disable IPV6 and install everything needs to run TJBot. It is working fine.

