### PR TITLE
Update command for running tests

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -181,7 +181,7 @@ Use the `runTests.sh` script to run all of the hardware tests.
 
 ```
 cd ~/Desktop/tjbot/bootstrap
-sh runTests.sh
+./runTests.sh
 ```
 
 > This command assumes you have cloned the tjbot git repository to your Desktop. If you have cloned it to a different directory, be sure to update the path in the above command.


### PR DESCRIPTION
When I ran `sh runTests.sh` I saw:

`runTests.sh: 4: runTests.sh: Bad substitution`

I was able to run the tests as `./runTests.sh` instead.