### PR TITLE
Add support for Raspian (Stretch)

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -74,9 +74,9 @@ sudo apt-get -y dist-upgrade
 
 8. Install Node.js.
 
-We have tested TJBot with Node.js version 6 for Raspian (Jesse) and Node.js version 7 for Raspian (Stretch).
+We have tested TJBot with Node.js version 6 for Raspian (Jessie) and Node.js version 7 for Raspian (Stretch).
 
-> Install Node.js 6 for Raspian (Jesse)
+> Install Node.js 6 for Raspian (Jessie)
 ```
 curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 sudo apt-get install -y nodejs
@@ -90,7 +90,7 @@ sudo apt-get install -y nodejs
 
 > Note: TJBot will encounter problems with versions of Node.js older than 6.x.
 
-9. Install additional software packages.
+9. Install additional software packages (Jessie only).
 
 ```
 sudo apt-get install -y alsa-base alsa-utils libasound2-dev git pigpio

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -13,10 +13,10 @@ Perform the following operations to prepare your Raspberry Pi for becoming a TJB
 3. Run the following command.
 
 ```
-curl -sL http://ibm.biz/tjbot-bootstrap | bash -
+curl -sL http://ibm.biz/tjbot-bootstrap | sudo sh -
 ```
 
-> Note that this script will run certain commands as root using `sudo`, but the script itself should **not** be run as root.
+> Note that this script requires root access and must be run with `sudo`.
 
 ## Manual Setup
 
@@ -72,14 +72,23 @@ sudo apt-get -y dist-upgrade
 
 > During the upgrade, if you are asked about replacing the `lightdm.conf` file with the package maintainers version, say "Y".
 
-8. Install Node.js 6.x.
+8. Install Node.js.
 
+We have tested TJBot with Node.js version 6 for Raspian (Jesse) and Node.js version 7 for Raspian (Stretch).
+
+> Install Node.js 6 for Raspian (Jesse)
 ```
 curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 
-> TJBot will encounter problems with versions of Node.js older than 6.x. TJBot has not been tested with Node.js version 7 or higher.
+> Install Node.js 7 for Raspian (Stretch)
+```
+curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
+sudo apt-get install -y nodejs
+```
+
+> Note: TJBot will encounter problems with versions of Node.js older than 6.x.
 
 9. Install additional software packages.
 

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -159,7 +159,7 @@ else
 
     read -p "Would you like to install a newer version of Node.js? [Y/n] " choice </dev/tty
     case "$choice" in
-        "y" | "Y")
+        "" | "y" | "Y")
             read -p "Which version of Node.js would you like to install? [6/7] " node_version </dev/tty
             case "$node_version" in
                 "6" | "7")
@@ -245,7 +245,7 @@ echo "the built-in audio jack, we recommend NOT disabling the sound kernel"
 echo "modules."
 read -p "Disable sound kernel modules? [Y/n] " choice </dev/tty
 case "$choice" in
-    "y" | "Y")
+    "" | "y" | "Y")
         echo "Disabling the kernel modules for the built-in audio jack."
         cp $TJBOT_DIR/bootstrap/tjbot-blacklist-snd.conf /etc/modprobe.d/
         ;;

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -317,7 +317,7 @@ these in the config.js files for each recipe you wish to run."
 echo "For more detailed guides on setting up service credentials, please see the
 README file of each recipe, or search instructables.com for \"tjbot\"."
 echo ""
-read -p "Press enter to continue: " dummy
+read -p "Press enter to continue: "
 
 #----tests
 echo ""

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -42,6 +42,7 @@ if [ $RASPIAN_VERSION -ne 8 ] && [ $RASPIAN_VERSION -ne 9 ]; then
     echo "Raspian."
     echo ""
     read -p "Would you like to continue with setup? Y/n: " choice
+    shopt -s nocasematch
     case "$choice" in
         "n" )
             echo "OK, TJBot software will not be installed at this time."

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -40,11 +40,11 @@ case "$choice" in
     *) ;;
 esac
 
-#----test raspbian version: 8 is jesse, 9 is stretch
+#----test raspbian version: 8 is jessie, 9 is stretch
 RASPIAN_VERSION_ID=`cat /etc/os-release | grep VERSION_ID | cut -d '"' -f 2`
 RASPIAN_VERSION=`cat /etc/os-release | grep VERSION | grep -v ID | cut -d '"' -f 2`
 if [ $RASPIAN_VERSION_ID -ne 8 ] && [ $RASPIAN_VERSION_ID -ne 9 ]; then
-    echo "Warning: it looks like your Raspberry Pi is not running Raspian (Jesse)"
+    echo "Warning: it looks like your Raspberry Pi is not running Raspian (Jessie)"
     echo "or Raspian (Stretch). TJBot has only been tested on these versions of"
     echo "Raspian."
     echo ""
@@ -138,7 +138,7 @@ esac
 NODE_VERSION=$(node --version 2>&1)
 NODE_LEVEL=$(node --version 2>&1 | cut -d '.' -f 1 | awk '{print substr($0,2,1)}')
 
-# Node.js version 6 for Jesse
+# Node.js version 6 for Jessie
 if [ $RASPIAN_VERSION_ID -eq 8 ]; then
     RECOMMENDED_NODE_LEVEL="6"
 # Node.js version 7 for Stretch
@@ -180,7 +180,7 @@ fi
 #----install additional packages
 echo ""
 if [ $RASPIAN_VERSION_ID -eq 8 ]; then
-    echo "Installing additional software packages for Jesse (alsa, libasound2-dev, git, pigpio)"
+    echo "Installing additional software packages for Jessie (alsa, libasound2-dev, git, pigpio)"
     apt-get install -y alsa-base alsa-utils libasound2-dev git pigpio
 #elif [ $RASPIAN_VERSION -eq 9 ]; then
 #    echo "Installing additional software packages for Stretch (libasound2-dev)"

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -16,16 +16,18 @@ echo "-----------------------------------------------------------------------"
 echo "Welcome! Let's set up your Raspberry Pi with the TJBot software."
 echo ""
 echo "Important: This script was designed for setting up a Raspberry Pi after"
-echo "a clean install of Raspbian (Jessie). If you are running this on a"
+echo "a clean install of Raspbian. If you are running this script on a"
 echo "Raspberry Pi that you've used for other projects, please take a look at"
 echo "what this script does BEFORE running it to ensure you are comfortable"
 echo "with its actions (e.g. performing an OS update, installing software"
 echo "packages, removing old packages, etc.)"
 echo "-----------------------------------------------------------------------"
 
+#----turn off case matching for input
+shopt -s nocasematch
+
 #----confirm bootstrap
 read -p "Would you like to use this Raspberry Pi for TJBot? Y/n: " choice
-shopt -s nocasematch
 case "$choice" in
  "n" )
     echo "OK, TJBot software will not be installed at this time."
@@ -34,30 +36,45 @@ case "$choice" in
  *) ;;
 esac
 
+#----test raspbian version: 8 is jesse, 9 is stretch
+RASPIAN_VERSION=`cat /etc/os-release | grep VERSION_ID | cut -d '"' -f 2`
+if [ $RASPIAN_VERSION -ne 8 ] && [ $RASPIAN_VERSION -ne 9 ]; then
+    echo "Warning: it looks like your Raspberry Pi is not running Raspian (Jesse)"
+    echo "or Raspian (Stretch). TJBot has only been tested on these versions of"
+    echo "Raspian."
+    echo ""
+    read -p "Would you like to continue with setup? Y/n: " choice
+    case "$choice" in
+        "n" )
+            echo "OK, TJBot software will not be installed at this time."
+            exit
+            ;;
+        * ) ;;
+    esac
+fi
+
 #----setting TJBot name
 CURRENT_HOSTNAME=`cat /etc/hostname | tr -d " \t\n\r"`
 echo ""
 echo "Please enter a name for your TJBot. This will be used for the hostname of"
 echo "your Raspberry Pi."
 read -p "TJBot name (current: $CURRENT_HOSTNAME): " name
-shopt -s nocasematch
 if [ -z "${name// }" ]; then
     name=$CURRENT_HOSTNAME
 fi
 echo "Setting DNS hostname to $name"
-echo "$name" | sudo tee /etc/hostname >/dev/null 2>&1
-sudo sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\t$name/g" /etc/hosts
+echo "$name" | tee /etc/hostname >/dev/null 2>&1
+sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\t$name/g" /etc/hosts
 
 #----disabling ipv6
 echo ""
 echo "In some networking environments, disabling ipv6 may help your Pi get on"
 echo "the network."
 read -p "Disable ipv6? (y/N): " choice
-shopt -s nocasematch
 case "$choice" in
  "y" )
     echo "Disabling ipv6"
-    echo " ipv6.disable=1" | sudo tee -a /boot/cmdline.txt
+    echo " ipv6.disable=1" | tee -a /boot/cmdline.txt
     echo "ipv6 has been disabled. It will take effect after rebooting.";;
  *) ;;
 esac
@@ -67,13 +84,12 @@ echo ""
 echo "In some networking environments, using Google's nameservers may speed up"
 echo "DNS queries."
 read -p "Enable Google DNS? (y/N): " choice
-shopt -s nocasematch
 case "$choice" in
  "y" )
     echo "Adding Google DNS servers to /etc/resolv.conf"
-    if [ ! grep -q "nameserver 8.8.8.8" /etc/resolv.conf ]; then
-        echo "nameserver 8.8.8.8" | sudo tee -a /etc/resolv.conf
-        echo "nameserver 8.8.4.4" | sudo tee -a /etc/resolv.conf
+    if ! grep -q "nameserver 8.8.8.8" /etc/resolv.conf; then
+        echo "nameserver 8.8.8.8" | tee -a /etc/resolv.conf
+        echo "nameserver 8.8.4.4" | tee -a /etc/resolv.conf
     fi ;;
  *) ;;
 esac
@@ -81,13 +97,12 @@ esac
 #----setting local to US
 echo ""
 read -p "Force locale to US English (en-US)? (y/N): " choice
-shopt -s nocasematch
 case "$choice" in
  "y" )
     echo "Forcing locale to en-US. Please ignore any errors below."
     export LC_ALL="en_US.UTF-8"
-    echo "en_US.UTF-8 UTF-8" | sudo tee -a /etc/locale.gen
-    sudo locale-gen en_US.UTF-8
+    echo "en_US.UTF-8 UTF-8" | tee -a /etc/locale.gen
+    locale-gen en_US.UTF-8
     ;;
  *) ;;
 esac
@@ -97,7 +112,6 @@ echo ""
 echo "TJBot requires an up-to-date installation of your Raspberry Pi's operating"
 echo "system software."
 read -p "Proceed with apt-get dist-upgrade? (Y/n): " choice
-shopt -s nocasematch
 case "$choice" in
  "n" )
     echo "Warning: you may encounter problems running TJBot recipes without performing"
@@ -106,9 +120,9 @@ case "$choice" in
     ;;
  *)
     echo "Updating apt repositories [apt-get update]"
-    sudo apt-get update
+    apt-get update
     echo "Upgrading OS distribution [apt-get dist-upgrade]"
-    sudo apt-get -y dist-upgrade
+    apt-get -y dist-upgrade
     ;;
 esac
 
@@ -118,11 +132,10 @@ echo ""
 echo "TJBot requires Node.js version 6. We detected Node.js version $node_version"
 echo "is already installed."
 read -p "Install Node 6.x? (Y/n): " choice
-shopt -s nocasematch
 case "$choice" in
  "y" )
-    curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
-    sudo apt-get install -y nodejs
+    curl -sL https://deb.nodesource.com/setup_6.x | bash -
+    apt-get install -y nodejs
     ;;
  *)
     echo "Warning: TJBot will encounter problems with versions of Node.js older than 6.x."
@@ -132,19 +145,23 @@ esac
 
 #----install additional packages
 echo ""
-echo "Installing additional software packages (alsa, libasound2, git, pigpio)"
-sudo apt-get install -y alsa-base alsa-utils libasound2-dev git pigpio
+if [ $RASPIAN_VERSION -eq 8 ]; then
+    echo "Installing additional software packages for Jesse (alsa, libasound2-dev, git, pigpio)"
+    apt-get install -y alsa-base alsa-utils libasound2-dev git pigpio
+#elif [ $RASPIAN_VERSION -eq 9 ]; then
+#    echo "Installing additional software packages for Stretch (libasound2-dev)"
+#    apt-get install -y libasound2-dev
+fi
 
 #----remove outdated apt packages
 echo ""
 echo "Removing unused software packages [apt-get autoremove]"
-sudo apt-get -y autoremove
+apt-get -y autoremove
 
 #----enable camera on raspbery pi
 echo ""
 echo "If your Raspberry Pi has a camera installed, TJBot can use it to see."
 read -p "Enable camera? (y/N): " choice
-shopt -s nocasematch
 case "$choice" in
  "y" )
     if grep "start_x=1" /boot/config.txt
@@ -154,15 +171,15 @@ case "$choice" in
         echo "Enabling camera."
         if grep "start_x=0" /boot/config.txt
         then
-            sudo sed -i "s/start_x=0/start_x=1/g" /boot/config.txt
+            sed -i "s/start_x=0/start_x=1/g" /boot/config.txt
         else
-            echo "start_x=1" | sudo tee -a /boot/config.txt >/dev/null 2>&1
+            echo "start_x=1" | tee -a /boot/config.txt >/dev/null 2>&1
         fi
         if grep "gpu_mem=128" /boot/config.txt
         then
             :
         else
-            echo "gpu_mem=128" | sudo tee -a /boot/config.txt >/dev/null 2>&1
+            echo "gpu_mem=128" | tee -a /boot/config.txt >/dev/null 2>&1
         fi
     fi
     ;;
@@ -179,7 +196,7 @@ fi
 
 if [ ! -d $TJBOT_DIR ]; then
     echo "Cloning TJBot project to $TJBOT_DIR"
-    git clone https://github.com/ibmtjbot/tjbot.git $TJBOT_DIR
+    sudo -u $SUDO_USER git clone https://github.com/ibmtjbot/tjbot.git $TJBOT_DIR
 else
     echo "TJBot project already exists in $TJBOT_DIR, leaving it alone"
 fi
@@ -193,15 +210,14 @@ echo "be able to play sound and use the LED at the same time. If you plan to use
 echo "the built-in audio jack, we recommend NOT disabling the sound kernel"
 echo "modules."
 read -p "Disable sound kernel modules? (Y/n): " choice
-shopt -s nocasematch
 case "$choice" in
  "y" )
     echo "Disabling the kernel modules for the built-in audio jack."
-    sudo cp $TJBOT_DIR/bootstrap/tjbot-blacklist-snd.conf /etc/modprobe.d/ 
+    cp $TJBOT_DIR/bootstrap/tjbot-blacklist-snd.conf /etc/modprobe.d/
     ;;
  "n" )
     echo "Enabling the kernel modules for the built-in audio jack."
-    sudo rm /etc/modprobe.d/tjbot-blacklist-snd.conf
+    rm /etc/modprobe.d/tjbot-blacklist-snd.conf
     ;;
  *) ;;
 esac
@@ -311,24 +327,22 @@ echo "sound configuration, we recommend rebooting first before running these"
 echo "tests as they may fail. You can run these tests at anytime by running"
 echo "the runTests.sh script in the tjbot/bootstrap folder."
 read -p "Would you like to run hardware tests at this time? (y/N): " choice
-shopt -s nocasematch
 case "$choice" in
- "y" )
-    ./runTests.sh $TJBOT_DIR
-    ;;
- *) ;;
+    "y" )
+        ./runTests.sh $TJBOT_DIR
+        ;;
+    *) ;;
 esac
 
 #----reboot
 echo ""
 read -p "We recommend rebooting for all changes to take effect. Reboot? (Y/n): " choice
-shopt -s nocasematch
 case "$choice" in
- "y" )
-    echo "Rebooting."
-    sudo reboot
-    ;;
- *)
-     echo "Please reboot your Raspberry Pi for all changes to take effect."
-    ;;
+    "y" )
+        echo "Rebooting."
+        reboot
+        ;;
+    *)
+        echo "Please reboot your Raspberry Pi for all changes to take effect."
+        ;;
 esac

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -57,6 +57,7 @@ echo ""
 echo "Please enter a name for your TJBot. This will be used for the hostname of"
 echo "your Raspberry Pi."
 read -p "TJBot name (current: $CURRENT_HOSTNAME): " name
+shopt -s nocasematch
 if [ -z "${name// }" ]; then
     name=$CURRENT_HOSTNAME
 fi
@@ -69,6 +70,7 @@ echo ""
 echo "In some networking environments, disabling ipv6 may help your Pi get on"
 echo "the network."
 read -p "Disable ipv6? (y/N): " choice
+shopt -s nocasematch
 case "$choice" in
  "y" )
     echo "Disabling ipv6"
@@ -82,6 +84,7 @@ echo ""
 echo "In some networking environments, using Google's nameservers may speed up"
 echo "DNS queries."
 read -p "Enable Google DNS? (y/N): " choice
+shopt -s nocasematch
 case "$choice" in
  "y" )
     echo "Adding Google DNS servers to /etc/resolv.conf"
@@ -95,6 +98,7 @@ esac
 #----setting local to US
 echo ""
 read -p "Force locale to US English (en-US)? (y/N): " choice
+shopt -s nocasematch
 case "$choice" in
  "y" )
     echo "Forcing locale to en-US. Please ignore any errors below."
@@ -110,6 +114,7 @@ echo ""
 echo "TJBot requires an up-to-date installation of your Raspberry Pi's operating"
 echo "system software."
 read -p "Proceed with apt-get dist-upgrade? (Y/n): " choice
+shopt -s nocasematch
 case "$choice" in
  "n" )
     echo "Warning: you may encounter problems running TJBot recipes without performing"
@@ -130,6 +135,7 @@ echo ""
 echo "TJBot requires Node.js version 6. We detected Node.js version $node_version"
 echo "is already installed."
 read -p "Install Node 6.x? (Y/n): " choice
+shopt -s nocasematch
 case "$choice" in
  "y" )
     curl -sL https://deb.nodesource.com/setup_6.x | bash -
@@ -160,6 +166,7 @@ apt-get -y autoremove
 echo ""
 echo "If your Raspberry Pi has a camera installed, TJBot can use it to see."
 read -p "Enable camera? (y/N): " choice
+shopt -s nocasematch
 case "$choice" in
  "y" )
     if grep "start_x=1" /boot/config.txt
@@ -208,6 +215,7 @@ echo "be able to play sound and use the LED at the same time. If you plan to use
 echo "the built-in audio jack, we recommend NOT disabling the sound kernel"
 echo "modules."
 read -p "Disable sound kernel modules? (Y/n): " choice
+shopt -s nocasematch
 case "$choice" in
  "y" )
     echo "Disabling the kernel modules for the built-in audio jack."
@@ -292,7 +300,7 @@ echo "Setup complete. Your Raspberry Pi is now set up as a TJBot! ;)"
 sleep $sleep_time
 echo "-------------------------------------------------------------------"
 echo ""
-read -p "Press enter to continue: " dummy
+read -p "Press enter to continue: "
 
 #——instructions for watson credentials
 echo "Notice about Watson services: Before running any recipes, you will need"
@@ -325,6 +333,7 @@ echo "sound configuration, we recommend rebooting first before running these"
 echo "tests as they may fail. You can run these tests at anytime by running"
 echo "the runTests.sh script in the tjbot/bootstrap folder."
 read -p "Would you like to run hardware tests at this time? (y/N): " choice
+shopt -s nocasematch
 case "$choice" in
     "y" )
         ./runTests.sh $TJBOT_DIR
@@ -335,6 +344,7 @@ esac
 #----reboot
 echo ""
 read -p "We recommend rebooting for all changes to take effect. Reboot? (Y/n): " choice
+shopt -s nocasematch
 case "$choice" in
     "y" )
         echo "Rebooting."

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -23,11 +23,9 @@ echo "with its actions (e.g. performing an OS update, installing software"
 echo "packages, removing old packages, etc.)"
 echo "-----------------------------------------------------------------------"
 
-#----turn off case matching for input
-shopt -s nocasematch
-
 #----confirm bootstrap
 read -p "Would you like to use this Raspberry Pi for TJBot? Y/n: " choice
+shopt -s nocasematch
 case "$choice" in
  "n" )
     echo "OK, TJBot software will not be installed at this time."

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -31,7 +31,7 @@ echo "packages, removing old packages, etc.)"
 echo "-----------------------------------------------------------------------"
 
 #----confirm bootstrap
-read -p "Would you like to use this Raspberry Pi for TJBot? [Y/n] " choice
+read -p "Would you like to use this Raspberry Pi for TJBot? [Y/n] " choice </dev/tty
 case "$choice" in
     "n" | "N")
         echo "OK, TJBot software will not be installed at this time."

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -7,12 +7,6 @@ if [ $user -ne 0 ]; then
     exit
 fi
 
-if [ -t 1 ]; then
-    echo "terminal"
-else
-    echo "not a terminal"
-fi
-
 #----ascii art!
 echo " _   _ _           _     _                 _       _                   "
 echo "| | (_) |         | |   | |               | |     | |                  "
@@ -37,7 +31,7 @@ echo "packages, removing old packages, etc.)"
 echo "-----------------------------------------------------------------------"
 
 #----confirm bootstrap
-read -p "Would you like to use this Raspberry Pi for TJBot? [Y/n] " choice
+read -p "Would you like to use this Raspberry Pi for TJBot? [Y/n] " choice </dev/tty
 case "$choice" in
     "n" | "N")
         echo "OK, TJBot software will not be installed at this time."
@@ -54,7 +48,7 @@ if [ $RASPIAN_VERSION_ID -ne 8 ] && [ $RASPIAN_VERSION_ID -ne 9 ]; then
     echo "or Raspian (Stretch). TJBot has only been tested on these versions of"
     echo "Raspian."
     echo ""
-    read -p "Would you like to continue with setup? [Y/n] " choice
+    read -p "Would you like to continue with setup? [Y/n] " choice </dev/tty
     case "$choice" in
         "n" | "N")
             echo "OK, TJBot software will not be installed at this time."
@@ -69,7 +63,7 @@ CURRENT_HOSTNAME=`cat /etc/hostname | tr -d " \t\n\r"`
 echo ""
 echo "Please enter a name for your TJBot. This will be used for the hostname of"
 echo "your Raspberry Pi."
-read -p "TJBot name (current: $CURRENT_HOSTNAME): " name
+read -p "TJBot name (current: $CURRENT_HOSTNAME): " name </dev/tty
 name=$(echo "$name" | tr -d ' ')
 if [ -z $name ]; then
     name=$CURRENT_HOSTNAME
@@ -82,7 +76,7 @@ sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\t$name/g" /etc/hosts
 echo ""
 echo "In some networking environments, disabling ipv6 may help your Pi get on"
 echo "the network."
-read -p "Disable ipv6? [y/N] " choice
+read -p "Disable ipv6? [y/N] " choice </dev/tty
 case "$choice" in
     "y" | "Y")
         echo "Disabling ipv6"
@@ -96,7 +90,7 @@ esac
 echo ""
 echo "In some networking environments, using Google's nameservers may speed up"
 echo "DNS queries."
-read -p "Enable Google DNS? [y/N]: " choice
+read -p "Enable Google DNS? [y/N]: " choice </dev/tty
 case "$choice" in
     "y" | "Y")
         echo "Adding Google DNS servers to /etc/resolv.conf"
@@ -110,7 +104,7 @@ esac
 
 #----setting local to US
 echo ""
-read -p "Force locale to US English (en-US)? [y/N] " choice
+read -p "Force locale to US English (en-US)? [y/N] " choice </dev/tty
 case "$choice" in
     "y" | "Y")
         echo "Forcing locale to en-US. Please ignore any errors below."
@@ -125,7 +119,7 @@ esac
 echo ""
 echo "TJBot requires an up-to-date installation of your Raspberry Pi's operating"
 echo "system software."
-read -p "Proceed with apt-get dist-upgrade? [Y/n] " choice
+read -p "Proceed with apt-get dist-upgrade? [Y/n] " choice </dev/tty
 case "$choice" in
     "n" | "N")
         echo "Warning: you may encounter problems running TJBot recipes without performing"
@@ -163,10 +157,10 @@ else
     echo "Node.js version $NODE_VERSION is currently installed. We recommend installing"
     echo "Node.js version $RECOMMENDED_NODE_LEVEL for Raspian $RASPIAN_VERSION."
 
-    read -p "Would you like to install a newer version of Node.js? [Y/n] " choice
+    read -p "Would you like to install a newer version of Node.js? [Y/n] " choice </dev/tty
     case "$choice" in
         "y" | "Y")
-            read -p "Which version of Node.js would you like to install? [6/7] " node_version
+            read -p "Which version of Node.js would you like to install? [6/7] " node_version </dev/tty
             case "$node_version" in
                 "6" | "7")
                     curl -sL https://deb.nodesource.com/setup_${node_version}.x | sudo bash -
@@ -201,7 +195,7 @@ apt-get -y autoremove
 #----enable camera on raspbery pi
 echo ""
 echo "If your Raspberry Pi has a camera installed, TJBot can use it to see."
-read -p "Enable camera? [y/N] " choice
+read -p "Enable camera? [y/N] " choice </dev/tty
 case "$choice" in
     "y" | "Y")
         if grep "start_x=1" /boot/config.txt
@@ -229,7 +223,7 @@ esac
 #----clone tjbot
 echo ""
 echo "We are ready to clone the TJBot project."
-read -p "Where should we clone it to? (default: /home/pi/Desktop/tjbot): " TJBOT_DIR
+read -p "Where should we clone it to? (default: /home/pi/Desktop/tjbot): " TJBOT_DIR </dev/tty
 if [ -z $TJBOT_DIR ]; then
     TJBOT_DIR='/home/pi/Desktop/tjbot'
 fi
@@ -249,7 +243,7 @@ echo "speaker via HDMI, USB, or Bluetooth, this is a safe operation and you will
 echo "be able to play sound and use the LED at the same time. If you plan to use"
 echo "the built-in audio jack, we recommend NOT disabling the sound kernel"
 echo "modules."
-read -p "Disable sound kernel modules? [Y/n] " choice
+read -p "Disable sound kernel modules? [Y/n] " choice </dev/tty
 case "$choice" in
     "y" | "Y")
         echo "Disabling the kernel modules for the built-in audio jack."
@@ -336,7 +330,7 @@ echo "Setup complete. Your Raspberry Pi is now set up as a TJBot! ;)"
 sleep $sleep_time
 echo "-------------------------------------------------------------------"
 echo ""
-read -p "Press enter to continue" nonce
+read -p "Press enter to continue" nonce </dev/tty
 
 #——instructions for watson credentials
 echo "Notice about Watson services: Before running any recipes, you will need"
@@ -359,7 +353,7 @@ these in the config.js files for each recipe you wish to run."
 echo "For more detailed guides on setting up service credentials, please see the
 README file of each recipe, or search instructables.com for \"tjbot\"."
 echo ""
-read -p "Press enter to continue" nonce
+read -p "Press enter to continue" nonce </dev/tty
 
 #----tests
 echo ""
@@ -368,7 +362,7 @@ echo "functioning properly. If you have made any changes to the camera or"
 echo "sound configuration, we recommend rebooting first before running these"
 echo "tests as they may fail. You can run these tests at anytime by running"
 echo "the runTests.sh script in the tjbot/bootstrap folder."
-read -p "Would you like to run hardware tests at this time? [y/N] " choice
+read -p "Would you like to run hardware tests at this time? [y/N] " choice </dev/tty
 case "$choice" in
     "y" | "Y")
         ./runTests.sh $TJBOT_DIR
@@ -378,7 +372,7 @@ esac
 
 #----reboot
 echo ""
-read -p "We recommend rebooting for all changes to take effect. Reboot? [Y/n] " choice
+read -p "We recommend rebooting for all changes to take effect. Reboot? [Y/n] " choice </dev/tty
 case "$choice" in
     "y" | "Y")
         echo "Rebooting."

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -7,6 +7,12 @@ if [ $user -ne 0 ]; then
     exit
 fi
 
+if [ -t 1 ]; then
+    echo "terminal"
+else
+    echo "not a terminal"
+fi
+
 #----ascii art!
 echo " _   _ _           _     _                 _       _                   "
 echo "| | (_) |         | |   | |               | |     | |                  "
@@ -31,7 +37,7 @@ echo "packages, removing old packages, etc.)"
 echo "-----------------------------------------------------------------------"
 
 #----confirm bootstrap
-read -p "Would you like to use this Raspberry Pi for TJBot? [Y/n] " choice </dev/tty
+read -p "Would you like to use this Raspberry Pi for TJBot? [Y/n] " choice
 case "$choice" in
     "n" | "N")
         echo "OK, TJBot software will not be installed at this time."
@@ -48,7 +54,7 @@ if [ $RASPIAN_VERSION_ID -ne 8 ] && [ $RASPIAN_VERSION_ID -ne 9 ]; then
     echo "or Raspian (Stretch). TJBot has only been tested on these versions of"
     echo "Raspian."
     echo ""
-    read -p "Would you like to continue with setup? [Y/n] " choice </dev/tty
+    read -p "Would you like to continue with setup? [Y/n] " choice
     case "$choice" in
         "n" | "N")
             echo "OK, TJBot software will not be installed at this time."
@@ -63,7 +69,7 @@ CURRENT_HOSTNAME=`cat /etc/hostname | tr -d " \t\n\r"`
 echo ""
 echo "Please enter a name for your TJBot. This will be used for the hostname of"
 echo "your Raspberry Pi."
-read -p "TJBot name (current: $CURRENT_HOSTNAME): " name </dev/tty
+read -p "TJBot name (current: $CURRENT_HOSTNAME): " name
 name=$(echo "$name" | tr -d ' ')
 if [ -z $name ]; then
     name=$CURRENT_HOSTNAME
@@ -76,7 +82,7 @@ sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\t$name/g" /etc/hosts
 echo ""
 echo "In some networking environments, disabling ipv6 may help your Pi get on"
 echo "the network."
-read -p "Disable ipv6? [y/N] " choice </dev/tty
+read -p "Disable ipv6? [y/N] " choice
 case "$choice" in
     "y" | "Y")
         echo "Disabling ipv6"
@@ -90,7 +96,7 @@ esac
 echo ""
 echo "In some networking environments, using Google's nameservers may speed up"
 echo "DNS queries."
-read -p "Enable Google DNS? [y/N]: " choice </dev/tty
+read -p "Enable Google DNS? [y/N]: " choice
 case "$choice" in
     "y" | "Y")
         echo "Adding Google DNS servers to /etc/resolv.conf"
@@ -104,7 +110,7 @@ esac
 
 #----setting local to US
 echo ""
-read -p "Force locale to US English (en-US)? [y/N] " choice </dev/tty
+read -p "Force locale to US English (en-US)? [y/N] " choice
 case "$choice" in
     "y" | "Y")
         echo "Forcing locale to en-US. Please ignore any errors below."
@@ -119,7 +125,7 @@ esac
 echo ""
 echo "TJBot requires an up-to-date installation of your Raspberry Pi's operating"
 echo "system software."
-read -p "Proceed with apt-get dist-upgrade? [Y/n] " choice </dev/tty
+read -p "Proceed with apt-get dist-upgrade? [Y/n] " choice
 case "$choice" in
     "n" | "N")
         echo "Warning: you may encounter problems running TJBot recipes without performing"
@@ -157,10 +163,10 @@ else
     echo "Node.js version $NODE_VERSION is currently installed. We recommend installing"
     echo "Node.js version $RECOMMENDED_NODE_LEVEL for Raspian $RASPIAN_VERSION."
 
-    read -p "Would you like to install a newer version of Node.js? [Y/n] " choice </dev/tty
+    read -p "Would you like to install a newer version of Node.js? [Y/n] " choice
     case "$choice" in
         "y" | "Y")
-            read -p "Which version of Node.js would you like to install? [6/7] " node_version </dev/tty
+            read -p "Which version of Node.js would you like to install? [6/7] " node_version
             case "$node_version" in
                 "6" | "7")
                     curl -sL https://deb.nodesource.com/setup_${node_version}.x | sudo bash -
@@ -195,7 +201,7 @@ apt-get -y autoremove
 #----enable camera on raspbery pi
 echo ""
 echo "If your Raspberry Pi has a camera installed, TJBot can use it to see."
-read -p "Enable camera? [y/N] " choice </dev/tty
+read -p "Enable camera? [y/N] " choice
 case "$choice" in
     "y" | "Y")
         if grep "start_x=1" /boot/config.txt
@@ -223,7 +229,7 @@ esac
 #----clone tjbot
 echo ""
 echo "We are ready to clone the TJBot project."
-read -p "Where should we clone it to? (default: /home/pi/Desktop/tjbot): " TJBOT_DIR </dev/tty
+read -p "Where should we clone it to? (default: /home/pi/Desktop/tjbot): " TJBOT_DIR
 if [ -z $TJBOT_DIR ]; then
     TJBOT_DIR='/home/pi/Desktop/tjbot'
 fi
@@ -243,7 +249,7 @@ echo "speaker via HDMI, USB, or Bluetooth, this is a safe operation and you will
 echo "be able to play sound and use the LED at the same time. If you plan to use"
 echo "the built-in audio jack, we recommend NOT disabling the sound kernel"
 echo "modules."
-read -p "Disable sound kernel modules? [Y/n] " choice </dev/tty
+read -p "Disable sound kernel modules? [Y/n] " choice
 case "$choice" in
     "y" | "Y")
         echo "Disabling the kernel modules for the built-in audio jack."
@@ -330,7 +336,7 @@ echo "Setup complete. Your Raspberry Pi is now set up as a TJBot! ;)"
 sleep $sleep_time
 echo "-------------------------------------------------------------------"
 echo ""
-read -p "Press enter to continue" nonce </dev/tty
+read -p "Press enter to continue" nonce
 
 #——instructions for watson credentials
 echo "Notice about Watson services: Before running any recipes, you will need"
@@ -353,7 +359,7 @@ these in the config.js files for each recipe you wish to run."
 echo "For more detailed guides on setting up service credentials, please see the
 README file of each recipe, or search instructables.com for \"tjbot\"."
 echo ""
-read -p "Press enter to continue" nonce </dev/tty
+read -p "Press enter to continue" nonce
 
 #----tests
 echo ""
@@ -362,7 +368,7 @@ echo "functioning properly. If you have made any changes to the camera or"
 echo "sound configuration, we recommend rebooting first before running these"
 echo "tests as they may fail. You can run these tests at anytime by running"
 echo "the runTests.sh script in the tjbot/bootstrap folder."
-read -p "Would you like to run hardware tests at this time? [y/N] " choice </dev/tty
+read -p "Would you like to run hardware tests at this time? [y/N] " choice
 case "$choice" in
     "y" | "Y")
         ./runTests.sh $TJBOT_DIR
@@ -372,7 +378,7 @@ esac
 
 #----reboot
 echo ""
-read -p "We recommend rebooting for all changes to take effect. Reboot? [Y/n] " choice </dev/tty
+read -p "We recommend rebooting for all changes to take effect. Reboot? [Y/n] " choice
 case "$choice" in
     "y" | "Y")
         echo "Rebooting."

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -48,7 +48,7 @@ if [ $RASPIAN_VERSION_ID -ne 8 ] && [ $RASPIAN_VERSION_ID -ne 9 ]; then
     echo "or Raspian (Stretch). TJBot has only been tested on these versions of"
     echo "Raspian."
     echo ""
-    read -p "Would you like to continue with setup? [Y/n] " choice
+    read -p "Would you like to continue with setup? [Y/n] " choice </dev/tty
     case "$choice" in
         "n" | "N")
             echo "OK, TJBot software will not be installed at this time."
@@ -63,7 +63,7 @@ CURRENT_HOSTNAME=`cat /etc/hostname | tr -d " \t\n\r"`
 echo ""
 echo "Please enter a name for your TJBot. This will be used for the hostname of"
 echo "your Raspberry Pi."
-read -p "TJBot name (current: $CURRENT_HOSTNAME): " name
+read -p "TJBot name (current: $CURRENT_HOSTNAME): " name </dev/tty
 name=$(echo "$name" | tr -d ' ')
 if [ -z $name ]; then
     name=$CURRENT_HOSTNAME
@@ -76,7 +76,7 @@ sed -i "s/127.0.1.1.*$CURRENT_HOSTNAME/127.0.1.1\t$name/g" /etc/hosts
 echo ""
 echo "In some networking environments, disabling ipv6 may help your Pi get on"
 echo "the network."
-read -p "Disable ipv6? [y/N] " choice
+read -p "Disable ipv6? [y/N] " choice </dev/tty
 case "$choice" in
     "y" | "Y")
         echo "Disabling ipv6"
@@ -90,7 +90,7 @@ esac
 echo ""
 echo "In some networking environments, using Google's nameservers may speed up"
 echo "DNS queries."
-read -p "Enable Google DNS? [y/N]: " choice
+read -p "Enable Google DNS? [y/N]: " choice </dev/tty
 case "$choice" in
     "y" | "Y")
         echo "Adding Google DNS servers to /etc/resolv.conf"
@@ -104,7 +104,7 @@ esac
 
 #----setting local to US
 echo ""
-read -p "Force locale to US English (en-US)? [y/N] " choice
+read -p "Force locale to US English (en-US)? [y/N] " choice </dev/tty
 case "$choice" in
     "y" | "Y")
         echo "Forcing locale to en-US. Please ignore any errors below."
@@ -119,7 +119,7 @@ esac
 echo ""
 echo "TJBot requires an up-to-date installation of your Raspberry Pi's operating"
 echo "system software."
-read -p "Proceed with apt-get dist-upgrade? [Y/n] " choice
+read -p "Proceed with apt-get dist-upgrade? [Y/n] " choice </dev/tty
 case "$choice" in
     "n" | "N")
         echo "Warning: you may encounter problems running TJBot recipes without performing"
@@ -157,10 +157,10 @@ else
     echo "Node.js version $NODE_VERSION is currently installed. We recommend installing"
     echo "Node.js version $RECOMMENDED_NODE_LEVEL for Raspian $RASPIAN_VERSION."
 
-    read -p "Would you like to install a newer version of Node.js? [Y/n] " choice
+    read -p "Would you like to install a newer version of Node.js? [Y/n] " choice </dev/tty
     case "$choice" in
         "y" | "Y")
-            read -p "Which version of Node.js would you like to install? [6/7] " node_version
+            read -p "Which version of Node.js would you like to install? [6/7] " node_version </dev/tty
             case "$node_version" in
                 "6" | "7")
                     curl -sL https://deb.nodesource.com/setup_${node_version}.x | sudo bash -
@@ -195,7 +195,7 @@ apt-get -y autoremove
 #----enable camera on raspbery pi
 echo ""
 echo "If your Raspberry Pi has a camera installed, TJBot can use it to see."
-read -p "Enable camera? [y/N] " choice
+read -p "Enable camera? [y/N] " choice </dev/tty
 case "$choice" in
     "y" | "Y")
         if grep "start_x=1" /boot/config.txt
@@ -223,7 +223,7 @@ esac
 #----clone tjbot
 echo ""
 echo "We are ready to clone the TJBot project."
-read -p "Where should we clone it to? (default: /home/pi/Desktop/tjbot): " TJBOT_DIR
+read -p "Where should we clone it to? (default: /home/pi/Desktop/tjbot): " TJBOT_DIR </dev/tty
 if [ -z $TJBOT_DIR ]; then
     TJBOT_DIR='/home/pi/Desktop/tjbot'
 fi
@@ -243,7 +243,7 @@ echo "speaker via HDMI, USB, or Bluetooth, this is a safe operation and you will
 echo "be able to play sound and use the LED at the same time. If you plan to use"
 echo "the built-in audio jack, we recommend NOT disabling the sound kernel"
 echo "modules."
-read -p "Disable sound kernel modules? [Y/n] " choice
+read -p "Disable sound kernel modules? [Y/n] " choice </dev/tty
 case "$choice" in
     "y" | "Y")
         echo "Disabling the kernel modules for the built-in audio jack."
@@ -330,7 +330,7 @@ echo "Setup complete. Your Raspberry Pi is now set up as a TJBot! ;)"
 sleep $sleep_time
 echo "-------------------------------------------------------------------"
 echo ""
-read -p "Press enter to continue" nonce
+read -p "Press enter to continue" nonce </dev/tty
 
 #——instructions for watson credentials
 echo "Notice about Watson services: Before running any recipes, you will need"
@@ -353,7 +353,7 @@ these in the config.js files for each recipe you wish to run."
 echo "For more detailed guides on setting up service credentials, please see the
 README file of each recipe, or search instructables.com for \"tjbot\"."
 echo ""
-read -p "Press enter to continue" nonce
+read -p "Press enter to continue" nonce </dev/tty
 
 #----tests
 echo ""
@@ -362,7 +362,7 @@ echo "functioning properly. If you have made any changes to the camera or"
 echo "sound configuration, we recommend rebooting first before running these"
 echo "tests as they may fail. You can run these tests at anytime by running"
 echo "the runTests.sh script in the tjbot/bootstrap folder."
-read -p "Would you like to run hardware tests at this time? [y/N] " choice
+read -p "Would you like to run hardware tests at this time? [y/N] " choice </dev/tty
 case "$choice" in
     "y" | "Y")
         ./runTests.sh $TJBOT_DIR
@@ -372,7 +372,7 @@ esac
 
 #----reboot
 echo ""
-read -p "We recommend rebooting for all changes to take effect. Reboot? [Y/n] " choice
+read -p "We recommend rebooting for all changes to take effect. Reboot? [Y/n] " choice </dev/tty
 case "$choice" in
     "y" | "Y")
         echo "Rebooting."


### PR DESCRIPTION
**Scope of Changes**
- added support for Raspian (Stretch) to the bootstrap script
- recommending Node.js version 7 for Stretch, Node.js version 6 for Jessie
- ensuring bootstrap is run as root
- made bootstrap script work in `sh`
- no need to install additional apt packages in Stretch because they come pre-installed

Successfully tested on a clean Raspian (Stretch) install with the speech_to_text and sentiment_analysis recipes.