### PR TITLE
fix running tests when bootstrap.sh run remotely

### DIFF
--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -368,7 +368,7 @@ echo ""
 read -p "Would you like to run hardware tests at this time? [y/N] " choice </dev/tty
 case "$choice" in
     "y" | "Y")
-        ./runTests.sh $TJBOT_DIR
+        $TJBOT_DIR/runTests.sh $TJBOT_DIR
         ;;
     *) ;;
 esac


### PR DESCRIPTION
The bootstrap script calls `./runTests.sh`, which may not be present if executed via `curl -sL http://ibm.biz/tjbot-bootstrap | sudo sh -`.    Use `$TJBOT_DIR/runTests.sh` instead.