### PR TITLE
Fix on STT credentials

### DIFF
--- a/recipes/speech_to_text/config.default.js
+++ b/recipes/speech_to_text/config.default.js
@@ -12,6 +12,6 @@ exports.credentials = {};
 // Watson Speech to Text
 // https://www.ibm.com/watson/services/speech-to-text/
 exports.credentials.speech_to_text = {
-    password: '',
-    username: ''
+    apikey: '',
+    url: ''
 };


### PR DESCRIPTION
parameters for newly instantiated speech to text instances requires the apikey and url instead of username and password