### PR TITLE
update test.camera.js to support node.js v10.15.0

### DIFF
--- a/bootstrap/tests/test.camera.js
+++ b/bootstrap/tests/test.camera.js
@@ -35,6 +35,6 @@ tj.takePhoto('picture.jpg').then(function(data) {
     }
     console.log("picture taken successfully, removing the file");
     if (fs.existsSync('picture.jpg')) {
-        fs.unlink('picture.jpg');
+        fs.unlinkSync('picture.jpg');
     }
 });


### PR DESCRIPTION
just changed line 38 to avoid the following error:
Unhandled rejection TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
    at makeCallback (fs.js:137:11)
    at Object.unlink (fs.js:939:14)
    at /home/pi/Desktop/tjbot/bootstrap/tests/test.camera.js:38:12
    at tryCatcher (/home/pi/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/home/pi/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/home/pi/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/home/pi/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/home/pi/node_modules/bluebird/js/release/promise.js:694:18)
    at _drainQueueStep (/home/pi/node_modules/bluebird/js/release/async.js:138:12)
    at _drainQueue (/home/pi/node_modules/bluebird/js/release/async.js:131:9)
    at Async._drainQueues (/home/pi/node_modules/bluebird/js/release/async.js:147:5)
    at Immediate.Async.drainQueues [as _onImmediate] (/home/pi/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)