### PR TITLE
update recipes and tests to depend on tjbot 2.0.1

### DIFF
--- a/recipes/conversation/package.json
+++ b/recipes/conversation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conversation",
   "description": "TJBot conversation recipe",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "TJBot <tjbot@us.ibm.com>",
   "bugs": {
     "url": "https://github.com/ibmtjbot/tjbot/issues"
@@ -27,6 +27,6 @@
     "eslint-plugin-import": "^2.22.1"
   },
   "dependencies": {
-    "tjbot": "^2.0.0"
+    "tjbot": "^2.0.1"
   }
 }

--- a/recipes/sentiment_analysis/package.json
+++ b/recipes/sentiment_analysis/package.json
@@ -1,13 +1,13 @@
 {
   "name": "sentiment",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "TJBot sentiment analysis recipe",
   "author": "TJBot <tjbot@us.ibm.com>",
   "bugs": {
     "url": "https://github.com/ibmtjbot/tjbot/issues"
   },
   "dependencies": {
-    "tjbot": "^2.0.0",
+    "tjbot": "^2.0.1",
     "twitter": "^1.7.1"
   },
   "main": "sentiment.js",

--- a/recipes/speech_to_text/package.json
+++ b/recipes/speech_to_text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speech_to_text",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "TJBot speech to text recipe",
   "author": "TJBot <tjbot@us.ibm.com>",
   "bugs": {
@@ -27,6 +27,6 @@
     "eslint-plugin-import": "^2.22.1"
   },
   "dependencies": {
-    "tjbot": "^2.0.0"
+    "tjbot": "^2.0.1"
   }
 }

--- a/recipes/translator/package.json
+++ b/recipes/translator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translator",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "TJBot language translator recipe",
   "author": "TJBot <tjbot@us.ibm.com>",
   "bugs": {
@@ -27,6 +27,6 @@
     "eslint-plugin-import": "^2.22.1"
   },
   "dependencies": {
-    "tjbot": "^2.0.0"
+    "tjbot": "^2.0.1"
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,14 +1,14 @@
 {
   "name": "tests",
   "description": "TJBot hardware tests",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "TJBot <tjbot@us.ibm.com>",
   "bugs": {
     "url": "https://github.com/ibmtjbot/tjbot/issues"
   },
   "dependencies": {
     "readline-sync": "^1.4.10",
-    "tjbot": "^2.0.0"
+    "tjbot": "^2.0.1"
   },
   "devDependencies": {
     "eslint": "^7.12.1",


### PR DESCRIPTION
with the update of tjbotlib to 2.0.1, the recipes and and tests need theie package.jsons to include the update dependency.  all recipe directories as well as the test directory were updated.