### PR TITLE
Updated OS and NodeJS version reqs, included test for ARMv6 processor…

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -74,19 +74,19 @@ $ sudo apt-get -y dist-upgrade
 
 8. Install Node.js.
 
-We recommend using Node.js v15.x or later.
+We recommend using Node.js v16.x or later.
 
 ```
-$ curl -sL https://deb.nodesource.com/setup_15.x | sudo -E bash -
+$ curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 $ sudo apt-get install -y nodejs
 ```
 
 > Note: TJBot may not function with earlier version of Node.js due to its use of ES6 modules.
 
-9. Install additional software packages (Jessie only).
+9. Install additional software packages.
 
 ```
-$ sudo apt-get install -y alsa-base alsa-utils libasound2-dev git pigpio
+$ sudo apt-get install -y libasound2-dev 
 ```
 
 10. _Optional_. Remove outdated software packages.

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -39,11 +39,23 @@ case "$choice" in
         ;;
     *) ;;
 esac
+echo
+
+CPUARCH=`lscpu |grep Arch |cut -d':' -f2 | awk '{$1=$1};1'`
+
+if [ $CPUARCH = 'armv6l' ];
+   then
+      echo "ARMv6 is not supported for TJBot due to software availability on this processor architecture. Please use another Raspberry Pi model"
+      exit 1
+else
+   echo "$CPUARCH processor architecture supported. Proceeding with setup"
+fi
+
 
 #----test raspbian version: if it's older than jessie, it may not work
-RASPIAN_VERSION_ID=`cat /etc/os-release | grep VERSION_ID | cut -d '"' -f 2`
-RASPIAN_VERSION=`cat /etc/os-release | grep VERSION= | cut -d '"' -f 2`
-if [ $RASPIAN_VERSION_ID -lt 8 ]; then
+RASPBIAN_VERSION_ID=`cat /etc/os-release | grep VERSION_ID | cut -d '"' -f 2`
+RASPBIAN_VERSION=`cat /etc/os-release | grep VERSION= | cut -d '"' -f 2`
+if [ $RASPBIAN_VERSION_ID -lt 8 ]; then
     echo "Warning: it looks like your Raspberry Pi is running an older version"
     echo "of Raspian. TJBot has only been tested on Raspian 8 (Jessie) and"
     echo "later."
@@ -136,9 +148,12 @@ case "$choice" in
 esac
 
 #----nodejs install
+apt-get -y install tidy >/dev/null
+
 echo ""
-RECOMMENDED_NODE_LEVEL="15"
-MIN_NODE_LEVEL="15"
+RECOMMENDED_NODE_LEVEL=`curl -sS https://nodejs.org/en/ |tidy -q 2>/dev/null |grep LTS |grep "Download " |cut -d' ' -f2 |cut -d'.' -f1`
+
+MIN_NODE_LEVEL="16"
 NEED_NODE_INSTALL=false
 
 if which node > /dev/null; then
@@ -169,13 +184,8 @@ fi
 
 #----install additional packages
 echo ""
-if [ $RASPIAN_VERSION_ID -eq 8 ]; then
-    echo "Installing additional software packages for Jessie (alsa, libasound2-dev, git, pigpio)"
-    apt-get install -y alsa-base alsa-utils libasound2-dev git pigpio
-#elif [ $RASPIAN_VERSION -eq 9 ]; then
-#    echo "Installing additional software packages for Stretch (libasound2-dev)"
-#    apt-get install -y libasound2-dev
-fi
+echo "Installing additional software packages (libasound2-dev)"
+apt-get install -y libasound2-dev
 
 #----remove outdated apt packages
 echo ""

--- a/featured/README.md
+++ b/featured/README.md
@@ -175,6 +175,9 @@ TJbot is a "zapping" friend connected to internet and to your TV, allowing elder
 
 ## Visual Recognition
 
+### [Microsoft Azure visual services](https://github.com/andycitron/tjBotFragmentThatUsesAzureVisualServices) by [@andycitron](https://github.com/andycitron)
+Example shows how to use Microsoft Azure's visual services to make TJBot see.
+
 ### [tjbot-visual-recognition](https://github.com/boxcarton/tjbot-visual-recognition) by [Joshua Zheng](https://github.com/boxcarton)
 #TJBot socializing with classic monsters.
 

--- a/featured/README.md
+++ b/featured/README.md
@@ -178,6 +178,8 @@ TJbot is a "zapping" friend connected to internet and to your TV, allowing elder
 ### [Microsoft Azure visual services](https://github.com/andycitron/tjBotFragmentThatUsesAzureVisualServices) by [@andycitron](https://github.com/andycitron)
 Example shows how to use Microsoft Azure's visual services to make TJBot see.
 
+[![Azure Visual Services](https://img.youtube.com/vi/B92efwFqXSs/0.jpg)](https://youtu.be/B92efwFqXSs)
+
 ### [tjbot-visual-recognition](https://github.com/boxcarton/tjbot-visual-recognition) by [Joshua Zheng](https://github.com/boxcarton)
 #TJBot socializing with classic monsters.
 


### PR DESCRIPTION
Updated minimum NodeJS version to 16, and added code to check automatically which is the latest version on nodejs.org and download latest LTS version.
Added test for Raspberry Pi A, A+, Zero, Zero W (ARMv6) and flag as not supported (No official NodeJS package, some AI libraries not available, old arch).
Updated OS to Bullseye as recommended.